### PR TITLE
DesignData

### DIFF
--- a/GameData/DesignData/DesignData.UnitTest.json
+++ b/GameData/DesignData/DesignData.UnitTest.json
@@ -1,0 +1,34 @@
+{
+	"table": "UnitTest",
+	"keys" : {
+		"EntryOne" :{
+			"intVar" : 1,
+			"floatVar" : 666.666,
+			"stringVar" : "cum",
+			"tableKeyVar" : "Menu[MainMenu]",
+			"intArr" : [6,2,4,2],
+			"floatArr" : [23.23, 13.37, 3.14, 6.34],
+			"stringArr" : ["poopies", "peepees", "thormax the devourer"],
+			"tableKeyArr" : [
+				"MenuItem[MainMenu.GameSelect]",
+				"MenuItem[MainMenu.Options]",
+				"MenuItem[ExitGame]"
+			],
+		},
+		"EntryTwo" :{
+			"intVar" : 6,
+			"floatVar" : 2.11,
+			"stringVar" : "pokemon",
+			"tableKeyVar" : "Menu[OptionsMenu]",
+			"intArr" : [1,2,3,4],
+			"floatArr" : [11.45, 555.1, 1.1, 3.1],
+			"stringArr" : ["thug", "ery", "forever"],
+			"tableKeyArr" : [
+				"MenuItem[GameSelect.DodgeTheCops]",
+				"MenuItem[GameSelect.DodgeDeezNuts]",
+				"MenuItem[GameSelect.DodgeTheJareds]",
+				"MenuItem[GameSelect.Back]"
+			],
+		}
+	}
+}

--- a/Scenes/Global/menu_system.gd
+++ b/Scenes/Global/menu_system.gd
@@ -15,10 +15,10 @@ func _process(delta: float) -> void:
 
 # Add a menu 
 func LoadMenu(menuKey: String) -> bool:
-	#Load the definition for the menu.
-	var menuDefinition := DesignData.GetDefinition(DesignData.CMenuDefinition.m_tableName, menuKey) as DesignData.CMenuDefinition
-	if menuDefinition == null:
-		print(get_script().get_path(), "Failed to Load Menu ", DesignData.CMenuDefinition.m_tableName, "[", menuKey, "]")
+	#Load the data for the menu.
+	var menuData := DesignData.GetData(DesignData.CMenuData.m_tableName, menuKey) as DesignData.CMenuData
+	if menuData == null:
+		print(get_script().get_path(), "Failed to Load Menu ", DesignData.CMenuData.m_tableName, "[", menuKey, "]")
 		return false
 	
 	#clear prev buttons
@@ -26,19 +26,19 @@ func LoadMenu(menuKey: String) -> bool:
 		remove_child(button)
 	menuButtons.clear()
 	
-	#menuDefinition.m_header
+	#menuData.m_header
 	
-	#For each menuItem in the menu definition, add a menuItem UI object.
+	#For each menuItem in the menu data, add a menuItem UI object.
 	var menuItemCount = 0
-	for tableKey:DesignData.CTableKey in menuDefinition.m_menuItems:
-		var menuItemDef := DesignData.GetDefinitionByTableKey(tableKey) as DesignData.CMenuItemDefinition
-		if menuItemDef != null:
-			createMenuItemInterfaceElement(menuItemDef, menuItemCount, menuDefinition.m_menuItems.size())
+	for tableKey:DesignData.CTableKey in menuData.m_menuItems:
+		var menuItemData := DesignData.GetDataByTableKey(tableKey) as DesignData.CMenuItemData
+		if menuItemData != null:
+			createMenuItemInterfaceElement(menuItemData, menuItemCount, menuData.m_menuItems.size())
 			menuItemCount = menuItemCount + 1
 
 	return true
 
-func createMenuItemInterfaceElement(menuItem: DesignData.CMenuItemDefinition, index: int, totalButtons: int) -> void:
+func createMenuItemInterfaceElement(menuItem: DesignData.CMenuItemData, index: int, totalButtons: int) -> void:
 	var text = menuItem.m_text
 	var button = Button.new()
 	var padding = 3
@@ -55,7 +55,12 @@ func createMenuItemInterfaceElement(menuItem: DesignData.CMenuItemDefinition, in
 	menuButtons.append(button)
 
 func buttonPressed(id:DesignData.CTableKey) -> void:
-	var menuItemDef := DesignData.GetDefinitionByTableKey(id) as DesignData.CMenuItemDefinition
+	var menuItemDef := DesignData.GetDataByTableKey(id) as DesignData.CMenuItemData
+	
+	if menuItemDef == null:
+		print(get_script().get_path(), ":: unable to load MenuItemData for id: ", id)
+		return
+	
 	var subMenu := menuItemDef.m_subMenu
 	var callBack := menuItemDef.m_callBack
 	

--- a/Scenes/main.gd
+++ b/Scenes/main.gd
@@ -3,46 +3,53 @@ extends Node2D
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	
-	DesignData.LoadTable(DesignData.CMenuDefinition.m_tableName)
-	DesignData.LoadTable(DesignData.CMenuItemDefinition.m_tableName)
+	DesignData.LoadTable(DesignData.CUnitTestData.m_tableName)
+	DesignData.LoadTable(DesignData.CMenuData.m_tableName)
+	DesignData.LoadTable(DesignData.CMenuItemData.m_tableName)
 	
-	PrintMenuData("MainMenu")
-	PrintMenuData("OptionsMenu")
-	PrintMenuData("GameSelectMenu")
-	PrintMenuData("Poopies")
+	#PrintMenuData("MainMenu")
+	#PrintMenuData("OptionsMenu")
+	#PrintMenuData("GameSelectMenu")
+	#PrintMenuData("Poopies")
+	RunDesignDataUnitTest()
 	
 	$MenuSystem.LoadMenu("MainMenu")
 	$MenuSystem.set_position(get_viewport_rect().size / 2)
+
+func RunDesignDataUnitTest():
+	var unitData := DesignData.GetData(DesignData.CUnitTestData.m_tableName, "EntryOne") as DesignData.CUnitTestData
+	if unitData != null:
+		print(unitData.GetContents(), "\n")
+	else:
+		print("Could not find data for ", DesignData.CUnitTestData.m_tableName, " ", "EntryThree")
 	
+	unitData = DesignData.GetData(DesignData.CUnitTestData.m_tableName, "EntryTwo") as DesignData.CUnitTestData
+	if unitData != null:
+		print(unitData.GetContents(), "\n")
+	else:
+		print("Could not find data for ", DesignData.CUnitTestData.m_tableName, " ", "EntryThree")
+	
+	unitData = DesignData.GetData(DesignData.CUnitTestData.m_tableName, "EntryThree") as DesignData.CUnitTestData
+	if unitData != null:
+		print(unitData.GetContents(), "\n")
+	else:
+		print("Could not find data for ", DesignData.CUnitTestData.m_tableName, " ", "EntryThree")
 
 func PrintMenuData(menuKey:StringName):
-	var menuDef:DesignData.CMenuDefinition = DesignData.GetDefinition(DesignData.CMenuDefinition.m_tableName, menuKey)
+	var menuDef:DesignData.CMenuData = DesignData.GetData(DesignData.CMenuData.m_tableName, menuKey)
 	if(menuDef == null):
-		print("PrintMenuData - could not find menu definition for: ", menuKey)
+		print("PrintMenuData - could not find MenuData for: ", menuKey)
 		return
-	print("table: ", menuDef.m_id.m_table)
-	print("key: ", menuDef.m_id.m_key)
-	print("header: ", menuDef.m_header)
 	
-	print( "menuDef to string: ", menuDef )
+	print( menuDef.GetContents(), "\n" )
 	
 	for tableKey in menuDef.m_menuItems:
-		var menuItemDef:DesignData.CMenuItemDefinition = DesignData.GetDefinitionByTableKey(tableKey)
+		var menuItemDef:DesignData.CMenuItemData = DesignData.GetDataByTableKey(tableKey)
 		if menuItemDef == null:
 			continue
-			
-		print("\ttable: ", menuItemDef.m_id.m_table)
-		print("\tkey: ", menuItemDef.m_id.m_key)
-		print("\ttext: ", menuItemDef.m_text)
-		print("\tsubText: ", menuItemDef.m_subText)
-		print("\tcallBack: ", menuItemDef.m_callBack)
-		print("\tcallBackParams: ", menuItemDef.m_callBackParams)
-		if menuItemDef.m_subMenu.m_table.length() == 0:
-			print("\tsubMenu: " )
-		else:
-			print("\tsubMenu: ", menuItemDef.m_subMenu.m_table, "[", menuItemDef.m_subMenu.m_key, "]" )
+		print(menuItemDef.GetContents("\t"))
 		print("")
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	pass


### PR DESCRIPTION
Made some type name changes.
The data stored at a tables key used to be called a CXDefinition in code. Now we just call it CXData
CMenuDefinition -> CMenuData
Also added an overloadable definition to string function so we can easily dump design data.

Also added several json data type loaders.
We now support design data types
int
float
string
tableKey
Array[int]
Array[float]
Array[string]
Array[tableKey]

Finally added in a new  DesignData.UnitTest.json
A data type which loads variables of every type, there by passing through all system error detection.